### PR TITLE
arch: drop pkg-config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -187,7 +187,7 @@ task:
   ccache_cache:
     folder: "/tmp/ccache_dir"
   install_script:
-    - pacman --noconfirm -Syu e2fsprogs cmake git gcc make pkg-config python3 boost libevent zeromq ccache qt5 qrencode
+    - pacman --noconfirm -Syu e2fsprogs cmake git gcc make python3 boost libevent zeromq ccache qt5 qrencode
     - ccache --max-size=${CCACHE_SIZE}
   upstream_clone_script:
     - git clone https://github.com/bitcoin/bitcoin --depth=1 ./bitcoin-core


### PR DESCRIPTION
Arch is one of the few distros that ships cmake config files for libevent, meaning that post
https://github.com/bitcoin/bitcoin/pull/31181, the system libs build should work without pkg-config. So drop the dep here. Probably worth having one job testing this, as we head further in that direction, i.e: https://github.com/bitcoin/bitcoin/pull/31276. Testing this locally the build worked, and from what I could tell, pkg-config wasn't being pulled in by a different dep.